### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/celery_jwt.py
+++ b/Alltechmanagement/celery_jwt.py
@@ -50,7 +50,7 @@ class CeleryJWTAuthentication(BaseAuthentication):
 
         except (InvalidToken, TokenError) as e:
             logger.error(f"CeleryJWTAuthentication: Error validating token - {str(e)}")
-            raise AuthenticationFailed(str(e))
+            raise AuthenticationFailed("Invalid token")
 
     def authenticate_header(self, request):
         logger.debug("CeleryJWTAuthentication: authenticate_header called")


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/1](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/1)

To fix the problem, we should avoid exposing the raw exception message to the end user. Instead, we can log the detailed error message on the server and raise a generic `AuthenticationFailed` exception with a non-specific error message. This approach ensures that sensitive information is not exposed while still providing useful logging for debugging purposes.

- Modify the `except` block to log the detailed error message.
- Raise a generic `AuthenticationFailed` exception with a non-specific error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
