### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/views.py
+++ b/Alltechmanagement/views.py
@@ -386,12 +386,13 @@ async def refund2_api(request, id):
         except SAVED_TRANSACTIONS2_FIX.DoesNotExist:
             return None, 'Transaction not found'
         except Exception as e:
-            return None, str(e)
+            logging.error(f"Error in process_refund: {str(e)}")
+            return None, 'An internal error has occurred.'
 
     try:
         item, error = await process_refund()
         if error:
-            return Response({'error': error}, status=404)
+            return Response({'error': 'An internal error has occurred.'}, status=404)
 
         # Handle non-critical operations
         async def async_operations():


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/9](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/9)

To fix the problem, we need to ensure that detailed error messages are logged on the server while returning a generic error message to the user. This can be achieved by modifying the exception handling in the `process_refund` and `refund2_api` functions. Specifically, we will:
1. Log the detailed error message on the server using the `logging` module.
2. Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
