### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/views.py
+++ b/Alltechmanagement/views.py
@@ -312,7 +312,8 @@ async def delete_stock2_api(request, id):
 
         return Response({'status': 'success'}, status=status.HTTP_200_OK)
     except Exception as e:
-        return Response({"Error": str(e)})
+        logging.error(f"Error in delete_stock2_api: {e}", exc_info=True)
+        return Response({"Error": "An internal error has occurred."})
 
 
 @async_api_view(['PUT', 'PATCH'])
@@ -359,8 +360,9 @@ async def update_stock2_api(request, id):
         return Response(serializer_data, status=status.HTTP_200_OK)
 
     except Exception as e:
+        logging.error(f"Error in update_stock2_api: {e}", exc_info=True)
         return Response(
-            {"error": str(e)},
+            {"error": "An internal error has occurred."},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
 


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/8](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/8)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the response.

- Modify the exception handling blocks to log the detailed error message using the logging module.
- Return a generic error message to the user to avoid exposing sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
