### PR TITLE
Fix code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/views.py
+++ b/Alltechmanagement/views.py
@@ -268,8 +268,9 @@ async def add_stock2_api(request):
             return Response(serializer_data, status=status.HTTP_200_OK)
 
         except Exception as e:
+            logging.error(f"Error in add_stock2_api: {e}", exc_info=True)
             return Response(
-                {'error': str(e)},
+                {'error': 'An internal error has occurred.'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/6](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/6)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
