### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/views.py
+++ b/Alltechmanagement/views.py
@@ -196,8 +196,9 @@ async def sell_api(request, product_id):
             status=status.HTTP_404_NOT_FOUND
         )
     except Exception as e:
+        logging.error("An error occurred: %s", str(e))
         return Response(
-            {'error': str(e)},
+            {'error': 'An internal error has occurred!'},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
 


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/5](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/5)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the response.

1. Import the `logging` module if it is not already imported.
2. Replace the line that returns the string representation of the exception with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
