### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/views.py
+++ b/Alltechmanagement/views.py
@@ -154,8 +154,9 @@ async def sell_api(request, product_id):
         try:
             product, saved_transaction = await perform_db_operations()
         except ValueError as e:
+            logging.error("A value error occurred: %s", str(e))
             return Response(
-                {'error': str(e)},
+                {'error': 'A value error has occurred!'},
                 status=status.HTTP_400_BAD_REQUEST
             )
 


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/4](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/4)

To fix the problem, we need to ensure that any exception messages returned to the user are generic and do not expose sensitive information. Specifically, we should log the detailed exception message on the server and return a generic error message to the user. This approach maintains the ability to debug issues using server logs while protecting the user from potentially sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
