### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/custom_auth.py
+++ b/Alltechmanagement/custom_auth.py
@@ -91,4 +91,4 @@ class CustomJWTAuthentication(JWTAuthentication):
 
         except Exception as e:
             logger.error(f"Error getting user from token: {str(e)}")
-            raise AuthenticationFailed(str(e))
+            raise AuthenticationFailed('Authentication failed due to an internal error.')


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/3](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/3)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the `raise AuthenticationFailed` statement to use a generic message while logging the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
