### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/Alltechmanagement/custom_auth.py
+++ b/Alltechmanagement/custom_auth.py
@@ -66,7 +66,7 @@ class FirebaseAuthentication:
 
         except Exception as e:
             logger.error(f"Firebase token verification failed: {str(e)}")
-            raise AuthenticationFailed(f'Authentication failed: {str(e)}')
+            raise AuthenticationFailed('Authentication failed due to an internal error.')
 
 
 class CustomJWTAuthentication(JWTAuthentication):


### PR DESCRIPTION
Fixes [https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/2](https://github.com/johngachara/phone_shop_pos_backend/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and raise a generic `AuthenticationFailed` error without including the exception details.

- Modify the exception handling block in the `FirebaseAuthentication` class to log the detailed error message and raise a generic `AuthenticationFailed` error.
- Ensure that the detailed error message is logged using the existing `logger` instance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
